### PR TITLE
Update loader link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 ### Loader version:
 
-[**Web loader**](https://enaon.github.io/eucWatch/p8)  for the P8 - P22A/B/C/D/B1/C1 - pinetime
+[**Web loader**](https://enaon.github.io/eucWatch/p8-testing)  for the P8 - P22A/B/C/D/B1/C1 - pinetime
 
 [**Web loader**](https://enaon.github.io/eucWatch/dk08) for the DK08 (old)
 


### PR DESCRIPTION
Since the [installation process docs](https://enaon.github.io/eucWatch/tools/hackme/) refers to the `p8-testing` version for the web loader, I figured the README should also link to it instead of the old `p8` one. 